### PR TITLE
Better check on symlink location

### DIFF
--- a/src/server/handler.go
+++ b/src/server/handler.go
@@ -354,7 +354,7 @@ func (fs FileSystem) buildPath(rawPath string) (string, error) {
 
 	dir, _ := path.Split(p)
 
-	if !strings.Contains(final, dir) {
+	if !strings.HasPrefix(final, dir) {
 		return "", errors.New("invalid path resolution")
 	}
 


### PR DESCRIPTION
Moved to checking the file is in the correct base folder and not that the path contained the base folder path.